### PR TITLE
arm64: Fix the ARM userspace build

### DIFF
--- a/arch/arm64/include/uapi/asm/ptrace.h
+++ b/arch/arm64/include/uapi/asm/ptrace.h
@@ -71,11 +71,13 @@ struct user_pt_regs {
 	__u64		pstate;
 };
 
+#if defined (__LP64__)
 struct user_fpsimd_state {
 	__uint128_t	vregs[32];
 	__u32		fpsr;
 	__u32		fpcr;
 };
+#endif
 
 struct user_hwdebug_state {
 	__u32		dbg_info;

--- a/arch/arm64/include/uapi/asm/sigcontext.h
+++ b/arch/arm64/include/uapi/asm/sigcontext.h
@@ -46,12 +46,14 @@ struct _aarch64_ctx {
 
 #define FPSIMD_MAGIC	0x46508001
 
+#if defined (__LP64__)
 struct fpsimd_context {
 	struct _aarch64_ctx head;
 	__u32 fpsr;
 	__u32 fpcr;
 	__uint128_t vregs[32];
 };
+#endif
 
 /* ESR_EL1 context */
 #define ESR_MAGIC	0x45535201


### PR DESCRIPTION
 * __uint128_t is not defined on 32-bit.